### PR TITLE
Sdk 53

### DIFF
--- a/packages/react-native-blob-util/src/withReactNativeBlobUtil.ts
+++ b/packages/react-native-blob-util/src/withReactNativeBlobUtil.ts
@@ -102,7 +102,6 @@ const withReactNativeBlobUtil: ConfigPlugin = (config) => {
     return config;
   });
 
-
   withStringsXml(config, (config) => {
     ensureBlobProviderAuthorityString(
       config.modResults,

--- a/packages/react-native-siri-shortcut/src/__tests__/withReactNativeSiriShortcut.test.ts
+++ b/packages/react-native-siri-shortcut/src/__tests__/withReactNativeSiriShortcut.test.ts
@@ -26,14 +26,14 @@ describe(addSiriShortcutBridgingHeaderImport, () => {
 describe(addSiriShortcutAppDelegateImport, () => {
   it(`adds import to swift Expo Modules AppDelegate`, () => {
     expect(
-      addSiriShortcutAppDelegateImport(ExpoModulesSwiftAppDelegate, "swift")
+      addSiriShortcutAppDelegateImport(ExpoModulesSwiftAppDelegate, "swift"),
     ).toBe(null);
   });
 
   it(`adds import to objcpp Expo Modules AppDelegate`, () => {
     const results = addSiriShortcutAppDelegateImport(
       ExpoModulesAppDelegate,
-      "objcpp"
+      "objcpp",
     )!;
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
@@ -55,7 +55,7 @@ describe(addSiriShortcutAppDelegateInit, () => {
   it(`adds init to swift Expo Modules AppDelegate`, () => {
     const results = addSiriShortcutAppDelegateInit(
       ExpoModulesSwiftAppDelegate,
-      "swift"
+      "swift",
     );
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
@@ -69,13 +69,13 @@ describe(addSiriShortcutAppDelegateInit, () => {
   it(`adds init to objcpp Expo Modules AppDelegate`, () => {
     const results = addSiriShortcutAppDelegateInit(
       ExpoModulesAppDelegate,
-      "objcpp"
+      "objcpp",
     );
     // matches a static snapshot
     expect(results.contents).toMatchSnapshot();
     expect(results.contents).toMatch(/react-native-siri-shortcut-delegate/);
     expect(results.contents).toMatch(
-      /RNSSSiriShortcuts application:application/
+      /RNSSSiriShortcuts application:application/,
     );
     // did add new content
     expect(results.didMerge).toBe(true);
@@ -85,7 +85,7 @@ describe(addSiriShortcutAppDelegateInit, () => {
 
   it(`fails to add to a malformed app delegate`, () => {
     expect(() => addSiriShortcutAppDelegateInit(`foobar`, "objcpp")).toThrow(
-      /foobar/
+      /foobar/,
     );
   });
 });

--- a/packages/react-native-siri-shortcut/src/withReactNativeSiriShortcut.ts
+++ b/packages/react-native-siri-shortcut/src/withReactNativeSiriShortcut.ts
@@ -19,7 +19,7 @@ import path from "path";
  */
 const withReactNativeSiriShortcut: ConfigPlugin<void | string[]> = (
   config,
-  activityTypes
+  activityTypes,
 ) => {
   withSiriShortcutAppDelegate(config);
   withSiriEntitlements(config);
@@ -40,7 +40,7 @@ const withReactNativeSiriShortcut: ConfigPlugin<void | string[]> = (
 
 export function addSiriShortcutAppDelegateImport(
   src: string,
-  lang: string
+  lang: string,
 ): MergeResults | null {
   if (lang !== "swift") {
     // ObjC
@@ -58,7 +58,7 @@ export function addSiriShortcutAppDelegateImport(
 
 export function addSiriShortcutAppDelegateInit(
   src: string,
-  lang: string
+  lang: string,
 ): MergeResults {
   if (lang === "swift") {
     return mergeContents({
@@ -112,13 +112,13 @@ const withSiriShortcutAppDelegate: ConfigPlugin = (config) => {
         absolute: true,
         cwd: path.join(
           config.modRequest.platformProjectRoot,
-          config.modRequest.projectName!
+          config.modRequest.projectName!,
         ),
       });
 
       if (!using) {
         throw new Error(
-          "Cannot find bridging header. Please make sure you have a bridging header in your project."
+          "Cannot find bridging header. Please make sure you have a bridging header in your project.",
         );
       }
 
@@ -136,23 +136,23 @@ const withSiriShortcutAppDelegate: ConfigPlugin = (config) => {
     if (!["objc", "objcpp", "swift"].includes(config.modResults.language)) {
       throw new Error(
         "Cannot setup Siri Shortcut because the AppDelegate is not in a support language:" +
-          ` ${config.modResults.language}. Only ObjC, ObjCpp and Swift are supported.`
+          ` ${config.modResults.language}. Only ObjC, ObjCpp and Swift are supported.`,
       );
     }
     try {
       config.modResults.contents =
         addSiriShortcutAppDelegateImport(
           config.modResults.contents,
-          config.modResults.language
+          config.modResults.language,
         )?.contents ?? config.modResults.contents;
       config.modResults.contents = addSiriShortcutAppDelegateInit(
         config.modResults.contents,
-        config.modResults.language
+        config.modResults.language,
       ).contents;
     } catch (error: any) {
       if (error.code === "ERR_NO_MATCH") {
         throw new Error(
-          `Cannot add Siri Shortcut to the project's AppDelegate because it's malformed. Please report this with a copy of your project AppDelegate.`
+          `Cannot add Siri Shortcut to the project's AppDelegate because it's malformed. Please report this with a copy of your project AppDelegate.`,
         );
       }
       throw error;
@@ -176,5 +176,5 @@ const pkg = {
 export default createRunOncePlugin(
   withReactNativeSiriShortcut,
   pkg.name,
-  pkg.version
+  pkg.version,
 );


### PR DESCRIPTION
Why
The primary motivation for this update was to resolve the existing Prettier formatting issues that were preventing the PR from passing its automated checks. Addressing these ensures adherence to the project's code style guidelines and allows the PR to proceed towards merging.

How
The Prettier issues were resolved by applying the Prettier formatter to the affected files. This automatically corrected any formatting inconsistencies according to the project's configured rules.

Test Plan
This change was tested by running the project's standard linting and formatting checks. Specifically, I verified that the Prettier-related checks (e.g., npm run lint or a similar command that includes Prettier) now pass without any errors or warnings. A reviewer can reproduce this by checking out this branch and executing the project's designated linting or formatting command to confirm that all style checks are clear.